### PR TITLE
fix(ui): adjust navbar item alignment

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1011,7 +1011,7 @@ export const NavbarPlexicus = ({
             {t("nav.contact")}
           </Link>
         </nav>
-        <div className="flex flex-end items-center justify-center max-w-[100px] ml-4">
+        <div className="flex flex-end items-center justify-center ml-4">
           <div className="hidden xl:flex  items-center gap-4">
             <SearchButton />
             <div className={cn("flex items-center gap-4 transition-all transition-discrete delay-0")}>


### PR DESCRIPTION
The navbar's contact link was misaligned due to an incorrect `max-w-[100px]` class on its parent div. This commit removes that class to ensure proper alignment of the contact link within the navbar.

## Checklist

- [ ] Is the task part of a larger feature or epic?
- [ ] Has the task been assigned to the correct sprint or milestone?
- [ ] Is there a related GitHub issue or card?
- [ ] Does the pull request include relevant tests?
- [ ] Have you updated the documentation (if needed)?

## Comments

Please provide any additional context or comments that are helpful for reviewers.
